### PR TITLE
fix(actions): improve onboarding messaging & remove invalid token check

### DIFF
--- a/.github/workflows/org-invite-codeheat.yml
+++ b/.github/workflows/org-invite-codeheat.yml
@@ -118,9 +118,15 @@ jobs:
               );
             }
 
-            const orgStatusLine = invited
-              ? `• Org invitation: **${membership.data.state}**\n`
-              : `• Org membership: **already active**\n`;
+            let orgStatusLine;
+
+            if (membership.data.state === 'pending') {
+              orgStatusLine = invited
+                ? `• Org invitation: **pending**\n`
+                : `• Org membership: **pending (invited earlier)**\n`;
+            } else {
+              orgStatusLine = `• Org membership: **active**\n`;
+            }
 
             const teamStatusLine = teamMembership
               ? `• Team membership: **${teamMembership.data.state}**\n`


### PR DESCRIPTION
Fixes: #18

## Summary by Sourcery

Improve the organization onboarding GitHub Action to better handle missing secrets, distinguish between existing members and new invites, and provide clearer feedback messages.

Bug Fixes:
- Stop treating a valid but unset ORG_ADMIN_TOKEN as an invalid runtime token inside the GitHub Script step by relying on an explicit pre-check instead.
- Correct organization membership handling by first checking existing membership and only attempting to invite users who are not yet members, avoiding failures when users already belong to the org.

Enhancements:
- Add an explicit debug step to detect and fail early when the ORG_ADMIN_TOKEN secret is not available in the workflow environment.
- Refine onboarding comments to clearly differentiate between new invitations and existing active members, and to provide actionable guidance when an invitation is pending.
- Improve error reporting for failures when retrieving organization membership or sending invitations, including more descriptive user-facing messages.