### PR TITLE
docs(readme): add Codeheat contributor onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Welcome to **Codeheat**! This guide explains how to join the **FOSSASIA GitHub o
 
 ### Step 1: Request to Join
 
-1. Open a new issue using the  
-   **“Join FOSSASIA and the Codeheat Team”** issue template.
+1. Open a new onboarding issue using this link:  
+   **[Join FOSSASIA and the Codeheat Team](https://github.com/fossasia/Codeheat/issues/new?template=join-codeheat.md)**
 2. Add a short introduction or reason for joining Codeheat.
 3. Submit the issue.
 
@@ -23,13 +23,15 @@ Once the issue is labeled:
   - Organization membership status
   - Codeheat team membership status
 
+**Typical processing time:** a few seconds to a minute.
+
 ### Step 3: Accept the Invitation (If Required)
 
 If your org membership status is **pending**:
 - Check your **GitHub notifications or email**
 - Accept the **FOSSASIA organization invitation**
 
-After accepting, your onboarding is complete
+After accepting the invitation, your onboarding is complete.
 
 ## Common Status Messages
 
@@ -41,6 +43,14 @@ After accepting, your onboarding is complete
 
 - **Team membership: pending / active**  
   Team access will be granted automatically after org membership is confirmed.
+
+## If Something Goes Wrong
+
+If you don’t see a response within a few minutes, or onboarding does not complete:
+
+- Make sure you’ve accepted the GitHub organization invitation
+- Comment on your onboarding issue requesting help
+- If needed, politely ping a maintainer for manual assistance
 
 ## Final Step
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,54 @@
 
 Join us for the Codeheat contest at https://codeheat.org
 
+## Codeheat Contributor Onboarding Guide
+
+Welcome to **Codeheat**! This guide explains how to join the **FOSSASIA GitHub organization** and get added to the **Codeheat team**.
+
+### Step 1: Request to Join
+
+1. Open a new issue using the  
+   **“Join FOSSASIA and the Codeheat Team”** issue template.
+2. Add a short introduction or reason for joining Codeheat.
+3. Submit the issue.
+
+> The issue will automatically receive the `org-invite` label.
+
+### Step 2: Automated Processing
+
+Once the issue is labeled:
+- A GitHub Action will process your request
+- You’ll receive a comment showing your onboarding status:
+  - Organization membership status
+  - Codeheat team membership status
+
+### Step 3: Accept the Invitation (If Required)
+
+If your org membership status is **pending**:
+- Check your **GitHub notifications or email**
+- Accept the **FOSSASIA organization invitation**
+
+After accepting, your onboarding is complete
+
+## Common Status Messages
+
+- **Org membership: active**  
+  You’re already part of FOSSASIA — no action needed.
+
+- **Org invitation: pending**  
+  Please accept the invitation to complete onboarding.
+
+- **Team membership: pending / active**  
+  Team access will be granted automatically after org membership is confirmed.
+
+## Final Step
+
+Once processed, the onboarding issue will be **automatically closed**.
+
+If you face any issues, feel free to comment on your onboarding issue or contact a maintainer.
+
+Happy coding!
+
 # Archive
 
 ### mbdyn tasks archive


### PR DESCRIPTION
### Summary
This PR adds a clear and concise onboarding guide for Codeheat contributors.

### What’s included
- Step-by-step instructions for requesting org and team access
- Explanation of automated onboarding via GitHub Actions
- Clarification of org vs team membership and pending states
- Reduced dependency on maintainers for manual guidance

### Result
New contributors can onboard independently with a consistent, well-documented flow.

---

Fixes #27

## Summary by Sourcery

Documentation:
- Document the Codeheat contributor onboarding flow, including org/team access, automated processing, status messages, and troubleshooting, in the README.